### PR TITLE
try to compile to string as much as possible

### DIFF
--- a/test/forest/test/compiler.clj
+++ b/test/forest/test/compiler.clj
@@ -14,10 +14,9 @@
 
   (testing "Declarations"
     (are [x y] (= (compiler/compile-declaration x) y)
-      `[:font-size "12px"] `(str "  font-size: " "12px")
+      `[:font-size "12px"] "  font-size: 12px"
       `[:font-size some-value] `(str "  font-size: " some-value)
-      `["transition" "width 1s linear"] `(str "  transition: "
-                                              "width 1s linear")))
+      `["transition" "width 1s linear"] "  transition: width 1s linear"))
 
   (testing "Declaration blocks"
     (are [x y] (= (eval (compiler/compile-declaration-block x)) y)


### PR DESCRIPTION
This branch adds few modifications which make forest compile stylesheets to this:

```
test.root.root_styles = new cljs.core.PersistentArrayMap(null, 2, [new cljs.core.Keyword(null,"source","source",-433931539),".test_root_root-styles__nav\n{\n  align-items: center\n}\n\n.test_root_root-styles__icon\n{\n  margin-right: 32px\n}",new cljs.core.Keyword(null,"full-name","full-name",408178550),"test.root/root-styles"], null);
```

rather than current version:

```
test.root.root_styles = new cljs.core.PersistentArrayMap(null, 2, [new cljs.core.Keyword(null,"source","source",-433931539),clojure.string.join.call(null,"\n\n",new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [[cljs.core.str(".test_root_root-styles__nav"),cljs.core.str("\n{\n"),cljs.core.str(clojure.string.join.call(null,";\n",new cljs.core.PersistentVector(null, 1, 5, cljs.core.PersistentVector.EMPTY_NODE, ["  align-items: center"], null))),cljs.core.str("\n}")].join(''),[cljs.core.str(".test_root_root-styles__icon"),cljs.core.str("\n{\n"),cljs.core.str(clojure.string.join.call(null,";\n",new cljs.core.PersistentVector(null, 1, 5, cljs.core.PersistentVector.EMPTY_NODE, ["  margin-right: 32px"], null))),cljs.core.str("\n}")].join('')], null)),new cljs.core.Keyword(null,"full-name","full-name",408178550),"test.root/root-styles"], null);
```

This obviously speeds up loading a bit plus reduces file size (even with advanced minification). I guess it could be improved further, so that if a single variable is used, everything except for this one variable is converted to a string - but that is a little bit more work. :)